### PR TITLE
fix delete product uses broad exception

### DIFF
--- a/product/models.py
+++ b/product/models.py
@@ -29,13 +29,9 @@ class Product(models.Model):
         try:
             Product.full_clean(self)
         except ValidationError as e:
-            self.delete_product(self.qr_code)
+            self.delete()
             raise e
         return self
 
-    @staticmethod
-    def delete_product(prd_qr):
-        try:
-            Product.filter_qr(prd_qr).delete()
-        except Exception:
-            pass
+    def delete_product(self):
+        Product.objects.get(qr_code=self.qr_code).delete()

--- a/product/tests/test_product.py
+++ b/product/tests/test_product.py
@@ -24,12 +24,19 @@ def saved_product0(product0):
 
 class TestProductModel:
     @pytest.mark.django_db()
-    def test_save_product_and_delete_product(self, saved_product0):
+    def test_save_delete_product(self, saved_product0):
+        temp = Product(saved_product0.qr_code, saved_product0.product_name, saved_product0.description)
         assert saved_product0 in Product.objects.all()
-        Product.delete_product(saved_product0.qr_code)
+        saved_product0.delete_product()
         assert saved_product0 not in Product.objects.all()
-        saved_product0.save_product()
-        assert saved_product0 in Product.objects.all()
+        temp.save()
+        assert temp in Product.objects.all()
+
+    @pytest.mark.django_db()
+    def test_delete_non_existing_product(self):
+        test_doesnotexist = Product("DOESNOTEXIST", "TEST", "TEST")
+        with pytest.raises(Product.DoesNotExist):
+            test_doesnotexist.delete_product()
 
     @pytest.mark.django_db()
     def test_filter_by_qr(self, saved_product0):


### PR DESCRIPTION
Here we are fixing the delete product function
that can cause an exception of not exist product
so we catch it and raise it after deleting it(after the save) and if it does exist it deletes it and
returns true.
- fixed #37 