### PR TITLE
Add ordered_product pages

### DIFF
--- a/buy_together/urls.py
+++ b/buy_together/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     path('', include('buy_together_app.urls')),
     path('products/', include('product.urls')),
     path('suppliers/', include('supplier.urls')),
+    path('ordered_product/', include('ordered_product.urls'))
 ]

--- a/conftest.py
+++ b/conftest.py
@@ -45,6 +45,15 @@ def supplier0():
                            business_name=TestFields['BUSINESS_NAME_TEST'].value)
 
 
+@pytest.fixture()
+def supplier1():
+    return models.Supplier(supplier_account=User.objects.create_user(username='meitar1234',
+                           first_name='meitar',
+                           last_name='rizner',
+                           password='123456',),
+                           business_name='vegShop')
+
+
 @pytest.fixture
 def saved_supplier0(supplier0):
     """Saves the supplier fixture.
@@ -57,6 +66,12 @@ def saved_supplier0(supplier0):
     """
     models.Supplier.save_supplier(supplier0)
     return supplier0
+
+
+@pytest.fixture
+def saved_supplier1(supplier1):
+    models.Supplier.save_supplier(supplier1)
+    return supplier1
 
 
 @pytest.fixture()
@@ -160,6 +175,16 @@ def delivery_location1(delivery_location0):
 
 
 @pytest.fixture
+def delivery_location2(saved_supplier0):
+    return DeliveryLocation(user_name=saved_supplier0, location="Tel Aviv", date=datetime.date(2022, 12, 30))
+
+
+@pytest.fixture
+def delivery_location3(saved_supplier1):
+    return DeliveryLocation(user_name=saved_supplier1, location="Tel Aviv", date=datetime.date(2022, 12, 30))
+
+
+@pytest.fixture
 def ordered_product0(delivery_location0, saved_client0, saved_product0):
     supprod = SupplierProduct(
         supplier_product_id=63147,
@@ -175,3 +200,8 @@ def ordered_product0(delivery_location0, saved_client0, saved_product0):
         user_name=saved_client0,
         supplier_product_id=supprod,
         quantity=3)
+
+
+@pytest.fixture
+def client0_login(client, saved_client0):
+    client.force_login(user=saved_client0.client_account)

--- a/ordered_product/models.py
+++ b/ordered_product/models.py
@@ -44,6 +44,7 @@ class OrderedProduct(models.Model):
 
     def increase_quantity(self, qn):
         self.quantity += qn
+        self.save_ordered_product()
 
     @staticmethod
     def order(delivery, client, supplier_product, qn):
@@ -53,3 +54,6 @@ class OrderedProduct(models.Model):
             ordered_product = OrderedProduct.objects.create(delivery_location_id=delivery, user_name=client,
                                                             supplier_product_id=supplier_product, quantity=qn)
             return ordered_product.save_ordered_product()
+
+    def total_price(self):
+        return self.quantity*self.supplier_product_id.price

--- a/ordered_product/tests/test_create_new_ordered_product.py
+++ b/ordered_product/tests/test_create_new_ordered_product.py
@@ -1,0 +1,496 @@
+import pytest
+from ordered_product.models import OrderedProduct
+from client.models import Client
+from supplier_product.models import SupplierProduct
+from delivery_location.models import DeliveryLocation
+from product.models import Product
+from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.auth.models import User
+
+
+@pytest.fixture
+def invalid_supplier_product_id():
+    return '0'
+
+
+@pytest.fixture
+def invalid_delivery_location_id():
+    return '9797'
+
+
+def client_check(user):
+    try:
+        return Client.objects.get(client_account=user)
+    except ObjectDoesNotExist:
+        return False
+
+
+class TestsCreateNewOrderedProduct:
+    @pytest.mark.django_db()
+    def test_display_new_order_page(self, client, client0_login):
+        response = client.get('/ordered_product/new_order/')
+        assert response.status_code == 200
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert 'ordered_product/new_order.html' in template_names
+
+    @pytest.mark.django_db()
+    def test_get_available_products_by_valid_product_name(self, client, saved_supplier_product0, client0_login):
+        VALID_PRODUCT_NAME = saved_supplier_product0.qr_code.product_name
+        product = Product.objects.get(product_name=VALID_PRODUCT_NAME)
+        supplier_products_by_objects_filter = list(SupplierProduct.objects.filter(qr_code=product))
+        assert saved_supplier_product0 in supplier_products_by_objects_filter
+        response = client.get(
+            '/ordered_product/new_order/search_product_by_product_name',
+            {'product_name': VALID_PRODUCT_NAME}
+        )
+        assert response.status_code == 200
+        assert response.context['message'] == ""
+        supplier_products_by_the_web_view = list(response.context['supplier_products'])
+        supplier_products_by_the_web_view = sorted(
+            supplier_products_by_the_web_view, key=lambda supplier_product: supplier_product.supplier_product_id
+        )
+        supplier_products_by_objects_filter == sorted(
+            supplier_products_by_the_web_view, key=lambda supplier_product: supplier_product.supplier_product_id
+        )
+        assert supplier_products_by_the_web_view == supplier_products_by_objects_filter
+
+    @pytest.mark.django_db()
+    def test_get_products_by_invalid_product_name(self, client, client0_login):
+        INVALID_PRODUCT_NAME = 'Eggplant'
+        with pytest.raises(ObjectDoesNotExist):
+            Product.objects.get(product_name=INVALID_PRODUCT_NAME)
+        response = client.get(
+            '/ordered_product/new_order/search_product_by_product_name',
+            {'product_name': INVALID_PRODUCT_NAME}
+        )
+        assert response.status_code == 200
+        assert response.context['message'] == "Invalid product name"
+        assert list(response.context['supplier_products']) == []
+
+    @pytest.mark.django_db()
+    def test_get_unavailable_products_by_valid_product_name(self, client, saved_product1, client0_login):
+        PRODUCT_NAME = saved_product1.product_name
+        supplier_products = SupplierProduct.objects.filter(qr_code=saved_product1)
+        assert list(supplier_products) == []
+        response = client.get(
+            '/ordered_product/new_order/search_product_by_product_name',
+            {'product_name': PRODUCT_NAME}
+        )
+        assert response.status_code == 200
+        assert response.context['message'] == "No products found"
+        assert list(response.context['supplier_products']) == []
+
+    @pytest.mark.django_db()
+    def test_get_available_products_valid_by_client_area(
+        self,
+        client,
+        saved_supplier_product0,
+        saved_client0,
+        delivery_location2,
+        client0_login
+    ):
+        delivery_location2.add_delivery_location()
+        assert delivery_location2.location == saved_client0.area
+        assert delivery_location2.user_name == saved_supplier_product0.user_name
+
+        deliveries_in_client_area = DeliveryLocation.objects.filter(location=saved_client0.area)
+        assert delivery_location2 in deliveries_in_client_area
+        supplier_products_by_objects_filter = []
+        for delivery in deliveries_in_client_area:
+            supplier_products_by_objects_filter += SupplierProduct.objects.filter(user_name=delivery.user_name)
+        assert saved_supplier_product0 in supplier_products_by_objects_filter
+        supplier_products_by_objects_filter = list(supplier_products_by_objects_filter)
+        response = client.get('/ordered_product/new_order/search_product_by_location')
+        assert response.status_code == 200
+        assert response.context['message'] == ""
+        supplier_products_by_the_web_view = list(response.context['supplier_products'])
+        supplier_products_by_the_web_view = sorted(
+            supplier_products_by_the_web_view, key=lambda supplier_product: supplier_product.supplier_product_id
+        )
+        supplier_products_by_objects_filter == sorted(
+            supplier_products_by_the_web_view, key=lambda supplier_product: supplier_product.supplier_product_id
+        )
+        assert supplier_products_by_the_web_view == supplier_products_by_objects_filter
+
+    @pytest.mark.django_db()
+    def test_get_products_by_invalid_client_area(self, client, client0_login):
+        INVALID_CLIENT_AREA = ''
+        deliveries_in_client_area = DeliveryLocation.objects.filter(location=INVALID_CLIENT_AREA)
+        assert list(deliveries_in_client_area) == []
+        response = client.get('/ordered_product/new_order/search_product_by_location')
+        assert response.status_code == 200
+        assert response.context['message'] == "No products found in your area"
+        assert response.context['supplier_products'] == []
+
+    @pytest.mark.django_db()
+    def test_get_unavailable_products_by_valid_client_area(
+        self,
+        client,
+        saved_client0,
+        delivery_location3,
+        client0_login
+    ):
+        delivery_location3.add_delivery_location()
+        assert saved_client0.area == delivery_location3.location
+
+        deliveries_in_client_area = DeliveryLocation.objects.filter(location=saved_client0.area)
+        assert delivery_location3 in deliveries_in_client_area
+        supplier_products_by_objects_filter = []
+        for delivery in deliveries_in_client_area:
+            supplier_products_by_objects_filter += SupplierProduct.objects.filter(user_name=delivery.user_name)
+        assert list(supplier_products_by_objects_filter) == []
+        response = client.get('/ordered_product/new_order/search_product_by_location')
+        assert response.status_code == 200
+        assert response.context['message'] == "No products found"
+        assert response.context['supplier_products'] == []
+
+    @pytest.mark.django_db()
+    def test_get_available_products_by_valid_supplier_user_name(
+        self,
+        client,
+        saved_supplier_product0,
+        saved_client0,
+        delivery_location2,
+        client0_login
+    ):
+        VALID_SUPPLIER_USER_NAME = saved_supplier_product0.user_name.supplier_account.username
+        delivery_location2.add_delivery_location()
+        assert delivery_location2.location == saved_client0.area
+        assert delivery_location2.user_name == saved_supplier_product0.user_name
+        supplier_products_by_objects_filter = list(SupplierProduct.objects.filter(
+            user_name=saved_supplier_product0.user_name
+        ))
+        assert saved_supplier_product0 in supplier_products_by_objects_filter
+        response = client.get(
+            '/ordered_product/new_order/search_supplier_catalog_by_user_name',
+            {'supplier_user_name': VALID_SUPPLIER_USER_NAME}
+        )
+        assert response.status_code == 200
+        assert response.context['message'] == ""
+        supplier_products_by_the_web_view = list(response.context['supplier_products'])
+        supplier_products_by_the_web_view = sorted(
+            supplier_products_by_the_web_view, key=lambda supplier_product: supplier_product.supplier_product_id
+        )
+        supplier_products_by_objects_filter == sorted(
+            supplier_products_by_the_web_view, key=lambda supplier_product: supplier_product.supplier_product_id
+        )
+        assert supplier_products_by_the_web_view == supplier_products_by_objects_filter
+
+    @pytest.mark.django_db()
+    def test_get_products_by_invalid_supplier_user_name(self, client, client0_login):
+        INVALID_SUPPLIER_USER_NAME = ''
+        with pytest.raises(ObjectDoesNotExist):
+            User.objects.get(username=INVALID_SUPPLIER_USER_NAME)
+        response = client.get(
+            '/ordered_product/new_order/search_supplier_catalog_by_user_name',
+            {'supplier_user_name': INVALID_SUPPLIER_USER_NAME}
+        )
+        assert response.status_code == 200
+        assert response.context['message'] == "Supplier no found"
+        assert response.context['supplier_products'] == []
+
+    @pytest.mark.django_db()
+    def test_get_products_by_valid_supplier_user_name_and_no_deliveries_in_client_area(
+        self,
+        client,
+        saved_client0,
+        saved_supplier0,
+        client0_login
+    ):
+        VALID_SUPPLIER_USER_NAME = saved_supplier0.supplier_account.username
+        deliveries_of_supplier0 = DeliveryLocation.objects.filter(user_name=saved_supplier0)
+        for delivery in deliveries_of_supplier0:
+            assert delivery.location != saved_client0.area
+        response = client.get(
+            '/ordered_product/new_order/search_supplier_catalog_by_user_name',
+            {'supplier_user_name': VALID_SUPPLIER_USER_NAME}
+        )
+        assert response.status_code == 200
+        assert response.context['message'] == "No products found in your area"
+        assert list(response.context['supplier_products']) == []
+
+    @pytest.mark.django_db()
+    def test_get_unavailable_products_by_valid_supplier_user_name(
+        self,
+        client,
+        saved_supplier1,
+        saved_client0,
+        delivery_location3,
+        client0_login
+    ):
+        VALID_SUPPLIER_USER_NAME = saved_supplier1.supplier_account.username
+        delivery_location3.add_delivery_location()
+        assert delivery_location3.location == saved_client0.area
+        assert delivery_location3.user_name == saved_supplier1
+        supplier_products_by_objects_filter = list(SupplierProduct.objects.filter(
+            user_name=saved_supplier1
+        ))
+        assert supplier_products_by_objects_filter == []
+        response = client.get(
+            '/ordered_product/new_order/search_supplier_catalog_by_user_name',
+            {'supplier_user_name': VALID_SUPPLIER_USER_NAME}
+        )
+        assert response.status_code == 200
+        assert response.context['message'] == "No products found"
+        supplier_products_by_the_web_view = list(response.context['supplier_products'])
+        supplier_products_by_the_web_view = sorted(
+            supplier_products_by_the_web_view, key=lambda supplier_product: supplier_product.supplier_product_id
+        )
+        supplier_products_by_objects_filter == sorted(
+            supplier_products_by_the_web_view, key=lambda supplier_product: supplier_product.supplier_product_id
+        )
+        assert supplier_products_by_the_web_view == supplier_products_by_objects_filter
+
+    @pytest.mark.django_db()
+    def test_find_valid_delivery_of_valid_supplier_product(
+        self,
+        client,
+        saved_client0,
+        saved_supplier0,
+        saved_supplier_product0,
+        delivery_location2,
+        client0_login
+    ):
+        delivery_location2.add_delivery_location()
+        assert saved_supplier_product0.user_name == saved_supplier0
+        assert delivery_location2.user_name == saved_supplier0
+        assert delivery_location2.location == saved_client0.area
+
+        response = client.get(
+            f'/ordered_product/new_order/find_delivery/{saved_supplier_product0.supplier_product_id}'
+        )
+        assert response.status_code == 200
+
+        template_names = set(
+            template.origin.template_name for template in response.templates
+        )
+        assert 'ordered_product/new_order.html' in template_names
+
+        delivery_location_by_objects_filter = DeliveryLocation.objects.filter(
+            user_name=saved_supplier0, location=saved_client0.area
+        )
+        assert delivery_location2 in delivery_location_by_objects_filter
+        assert response.context['message'] == ""
+        assert response.context['sup_pro_id'] == saved_supplier_product0.supplier_product_id
+        delivery_location_by_the_web_view = response.context['deliveries']
+        assert list(delivery_location_by_the_web_view) == list(delivery_location_by_objects_filter)
+
+    @pytest.mark.django_db()
+    def test_find_invalid_delivery_of_valid_supplier_product(
+        self,
+        client,
+        saved_client0,
+        saved_supplier0,
+        saved_supplier_product0,
+        delivery_location0,
+        client0_login
+    ):
+        delivery_location0.add_delivery_location()
+        assert saved_supplier_product0.user_name == saved_supplier0
+        assert delivery_location0.user_name == saved_supplier0
+        assert delivery_location0.location != saved_client0.area
+
+        response = client.get(
+            f'/ordered_product/new_order/find_delivery/{saved_supplier_product0.supplier_product_id}'
+        )
+        assert response.status_code == 200
+
+        template_names = set(
+            template.origin.template_name for template in response.templates
+        )
+        assert 'ordered_product/new_order.html' in template_names
+
+        delivery_location_by_objects_filter = DeliveryLocation.objects.filter(
+            user_name=saved_supplier0, location=saved_client0.area
+        )
+        assert delivery_location0 not in delivery_location_by_objects_filter
+        assert list(delivery_location_by_objects_filter) == []
+        assert response.context['message'] == "No delivery found at '"+saved_client0.area+"'"
+        assert response.context['sup_pro_id'] == saved_supplier_product0.supplier_product_id
+        delivery_location_by_the_web_view = response.context['deliveries']
+        assert list(delivery_location_by_the_web_view) == list(delivery_location_by_objects_filter)
+
+    @pytest.mark.django_db()
+    def test_find_delivery_of_invalid_supplier_product(self, client, invalid_supplier_product_id, client0_login):
+        with pytest.raises(ObjectDoesNotExist):
+            SupplierProduct.objects.get(supplier_product_id=invalid_supplier_product_id)
+        response = client.get('/ordered_product/new_order/find_delivery/'+invalid_supplier_product_id)
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+
+    @pytest.mark.django_db()
+    def test_valid_order_summary(
+        self,
+        client,
+        saved_supplier_product0,
+        delivery_location0,
+        client0_login
+    ):
+        delivery_location0.add_delivery_location()
+        supplier_product_by_objects_filter = SupplierProduct.objects.get(
+            supplier_product_id=saved_supplier_product0.supplier_product_id
+        )
+        delivery_location_by_objects_filter = DeliveryLocation.objects.get(
+            id=delivery_location0.id
+        )
+
+        assert saved_supplier_product0 == supplier_product_by_objects_filter
+        assert delivery_location0 == delivery_location_by_objects_filter
+
+        response = client.get(
+            f'/ordered_product/new_order/order_summary/'
+            f'{saved_supplier_product0.supplier_product_id},{delivery_location0.id}'
+        )
+        assert response.status_code == 200
+
+        template_names = set(
+            template.origin.template_name for template in response.templates
+        )
+        assert 'ordered_product/new_order.html' in template_names
+
+        supplier_products_by_the_web_view = response.context['supplier_product']
+        delivery_location_by_the_web_view = response.context['delivery_location']
+        assert supplier_products_by_the_web_view == supplier_product_by_objects_filter
+        assert delivery_location_by_the_web_view == delivery_location_by_objects_filter
+
+    @pytest.mark.django_db()
+    def test_invalid_order_summary(
+        self,
+        client,
+        invalid_delivery_location_id,
+        invalid_supplier_product_id,
+        client0_login
+    ):
+        with pytest.raises(ObjectDoesNotExist):
+            SupplierProduct.objects.get(supplier_product_id=invalid_supplier_product_id)
+        with pytest.raises(ObjectDoesNotExist):
+            DeliveryLocation.objects.get(id=invalid_delivery_location_id)
+
+        response = client.get(
+            f'/ordered_product/new_order/order_summary/'
+            f'{invalid_supplier_product_id},{invalid_delivery_location_id}'
+        )
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+
+    @pytest.mark.django_db()
+    def test_valid_complete_order(
+        self,
+        client,
+        saved_supplier_product0,
+        delivery_location0,
+        client0,
+        client0_login
+    ):
+        delivery_location0.add_delivery_location()
+        with pytest.raises(ObjectDoesNotExist):
+            OrderedProduct.objects.get(
+                delivery_location_id=delivery_location0.id,
+                user_name=client0,
+                supplier_product_id=saved_supplier_product0.supplier_product_id,
+                quantity=5
+            )
+
+        response = client.get(
+            f'/ordered_product/new_order/complete_order/'
+            f'{saved_supplier_product0.supplier_product_id},{delivery_location0.id}',
+            {'quantity': 5}
+        )
+        assert OrderedProduct.objects.get(
+            delivery_location_id=delivery_location0.id,
+            user_name=client0,
+            supplier_product_id=saved_supplier_product0.supplier_product_id,
+            quantity=5
+        )
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert template_names == set()
+
+    @pytest.mark.django_db()
+    def test_complete_order_invalid_quantity(
+        self,
+        client,
+        saved_supplier_product0,
+        delivery_location0,
+        client0,
+        client0_login
+    ):
+        invalid_quantity = 'a'
+        delivery_location0.add_delivery_location()
+        with pytest.raises(ValueError):
+            OrderedProduct.objects.get(
+                delivery_location_id=delivery_location0.id,
+                user_name=client0,
+                supplier_product_id=saved_supplier_product0.supplier_product_id,
+                quantity=invalid_quantity
+            )
+        response = client.get(
+            f'/ordered_product/new_order/complete_order/'
+            f'{saved_supplier_product0.supplier_product_id},{delivery_location0.id}',
+            {'quantity': invalid_quantity}
+        )
+        with pytest.raises(ValueError):
+            OrderedProduct.objects.get(
+                delivery_location_id=delivery_location0.id,
+                user_name=client0,
+                supplier_product_id=saved_supplier_product0.supplier_product_id,
+                quantity=invalid_quantity
+            )
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert template_names == set()
+
+    @pytest.mark.django_db()
+    def test_complete_order_invalid_supplier_product(
+        self,
+        client,
+        invalid_supplier_product_id,
+        delivery_location0,
+        client0,
+        client0_login
+    ):
+        delivery_location0.add_delivery_location()
+        with pytest.raises(ObjectDoesNotExist):
+            SupplierProduct.objects.get(supplier_product_id=invalid_supplier_product_id)
+
+        response = client.get(
+            f'/ordered_product/new_order/complete_order/'
+            f'{invalid_supplier_product_id},{delivery_location0.id}',
+            {'quantity': 5}
+        )
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert template_names == set()
+
+    @pytest.mark.django_db()
+    def test_complete_order_invalid_delivery_location(
+        self,
+        client,
+        saved_supplier_product0,
+        invalid_delivery_location_id,
+        client0,
+        client0_login
+    ):
+        with pytest.raises(ObjectDoesNotExist):
+            DeliveryLocation.objects.get(id=invalid_delivery_location_id)
+
+        response = client.get(
+            f'/ordered_product/new_order/complete_order/'
+            f'{saved_supplier_product0.supplier_product_id},{invalid_delivery_location_id}',
+            {'quantity': 5}
+        )
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert template_names == set()
+
+    @pytest.mark.django_db()
+    def test_pay_order(self, client, client0_login):
+        response = client.get('/ordered_product/new_order/pay_order')
+        template_names = set(
+            template.origin.template_name for template in response.templates
+        )
+        assert 'ordered_product/pay_order.html' in template_names

--- a/ordered_product/tests/test_edit_ordered_product.py
+++ b/ordered_product/tests/test_edit_ordered_product.py
@@ -1,0 +1,110 @@
+import pytest
+from ordered_product.models import OrderedProduct
+from client.models import Client
+from django.core.exceptions import ObjectDoesNotExist
+
+
+def client_check(user):
+    try:
+        return Client.objects.get(client_account=user)
+    except ObjectDoesNotExist:
+        return False
+
+
+class TestsEditOrderedProduct:
+    @pytest.mark.django_db()
+    def test_change_valid_positive_quantity_to_valid_order(
+        self,
+        client,
+        saved_client0,
+        ordered_product0,
+        client0_login
+    ):
+        positive_quantity = 5
+        ordered_product0.save_ordered_product()
+        assert ordered_product0.user_name == saved_client0
+        quantity_before_change = OrderedProduct.objects.get(id=ordered_product0.id).quantity
+        response = client.get(f'/ordered_product/orders/{ordered_product0.id}', {'quantity': positive_quantity})
+        quantity_after_change = OrderedProduct.objects.get(id=ordered_product0.id).quantity
+        assert quantity_after_change == quantity_before_change+positive_quantity
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert template_names == set()
+
+    @pytest.mark.django_db()
+    def test_change_valid_negative_quantity_to_valid_order(
+        self,
+        client,
+        saved_client0,
+        ordered_product0,
+        client0_login
+    ):
+        negative_quantity = -1
+        ordered_product0.save_ordered_product()
+        assert ordered_product0.quantity > 1
+        assert ordered_product0.user_name == saved_client0
+        quantity_before_change = OrderedProduct.objects.get(id=ordered_product0.id).quantity
+        response = client.get(f'/ordered_product/orders/{ordered_product0.id}', {'quantity': negative_quantity})
+        assert ordered_product0 in OrderedProduct.objects.all()
+        quantity_after_change = OrderedProduct.objects.get(id=ordered_product0.id).quantity
+        assert quantity_after_change == quantity_before_change+negative_quantity
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert template_names == set()
+
+    @pytest.mark.django_db()
+    def test_change_valid_zeroed_quantity_to_valid_order(self, client, saved_client0, ordered_product0, client0_login):
+        quantity = 0
+        ordered_product0.save_ordered_product()
+        assert ordered_product0.user_name == saved_client0
+        quantity_before_change = OrderedProduct.objects.get(id=ordered_product0.id).quantity
+        response = client.get(f'/ordered_product/orders/{ordered_product0.id}', {'quantity': quantity})
+        quantity_after_change = OrderedProduct.objects.get(id=ordered_product0.id).quantity
+        assert quantity_after_change == quantity_before_change
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert template_names == set()
+
+    @pytest.mark.django_db()
+    def test_change_invalid_quantity_to_valid_order(self, client, ordered_product0, client0_login):
+        ordered_product0.save_ordered_product()
+        invalid_quantity = 'a'
+        quantity_before_change = OrderedProduct.objects.get(id=ordered_product0.id).quantity
+        response = client.get(f'/ordered_product/orders/{ordered_product0.id}', {'quantity': invalid_quantity})
+        quantity_after_change = OrderedProduct.objects.get(id=ordered_product0.id).quantity
+        assert quantity_before_change == quantity_after_change
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert template_names == set()
+
+    @pytest.mark.django_db()
+    def test_change_valid_quantity_to_invalid_order(self, client, client0_login):
+        invalid_order_product_id = 'a'
+        with pytest.raises(ValueError):
+            OrderedProduct.objects.get(id=invalid_order_product_id)
+        response = client.get(f'/ordered_product/orders/{invalid_order_product_id}', {'quantity': 5})
+        assert response.status_code == 404
+
+    @pytest.mark.django_db()
+    def test_delete_valid_order(self, client, saved_client0, ordered_product0, client0_login):
+        assert ordered_product0.user_name == saved_client0
+        ordered_product0.save_ordered_product()
+        assert ordered_product0 in OrderedProduct.objects.filter(user_name=saved_client0)
+        response = client.get(f'/ordered_product/orders/{ordered_product0.id},delete')
+        assert ordered_product0 not in OrderedProduct.objects.filter(user_name=saved_client0)
+        assert response.status_code == 302
+        assert response['Location'] == '/client/'
+        template_names = set(template.origin.template_name for template in response.templates)
+        assert template_names == set()
+
+    @pytest.mark.django_db()
+    def test_delete_invalid_order(self, client, client0_login):
+        invalid_order_product_id = 'a'
+        with pytest.raises(ValueError):
+            OrderedProduct.objects.get(id=invalid_order_product_id)
+        response = client.get(f'/ordered_product/orders/{invalid_order_product_id},delete')
+        assert response.status_code == 404

--- a/ordered_product/tests/test_ordered_product.py
+++ b/ordered_product/tests/test_ordered_product.py
@@ -55,8 +55,7 @@ class TestOrderedProductModel():
         ordered_product0.quantity = 3
         ordered_product0.save_ordered_product()
         ordered_product0.increase_quantity(6)
-        assert ordered_product0.quantity == 9
-        assert ordered_product0 in OrderedProduct.objects.all()
+        assert OrderedProduct.objects.get(id=ordered_product0.id).quantity == 9
 
     @pytest.mark.django_db()
     def test_order(self, ordered_product0):

--- a/ordered_product/urls.py
+++ b/ordered_product/urls.py
@@ -1,0 +1,21 @@
+from django.urls import path
+from ordered_product import views
+
+urlpatterns = [
+     path('orders/<int:order_id>', views.change_quantity, name="orders"),
+     path('orders/<int:order_id>,delete', views.delete_order, name="orders"),
+     path('new_order/', views.order, name="new_order"),
+     path('new_order/search_product_by_product_name',
+          views.get_products_by_product_name, name="search_product_by_product_name"),
+     path('new_order/search_product_by_location',
+          views.get_products_by_client_area, name="search_product_by_location"),
+     path('new_order/search_supplier_catalog_by_user_name',
+          views.get_products_by_supplier_user_name, name="search_supplier_catalog_by_business_name"),
+     path('new_order/find_delivery/<int:supplier_product_id>',
+          views.find_delivery, name="find_delivery"),
+     path('new_order/order_summary/<int:supplier_product_id>,<int:delivery_location_id>',
+          views.order_summary, name="order_summary"),
+     path('new_order/complete_order/<int:supplier_product_id>,<int:delivery_location_id>',
+          views.complete_order, name="complete_order"),
+     path('new_order/pay_order', views.pay_order, name="search_supplier_catalog_by_business_name"),
+]

--- a/ordered_product/views.py
+++ b/ordered_product/views.py
@@ -1,0 +1,172 @@
+from .models import OrderedProduct
+from client.models import Client
+from supplier_product.models import SupplierProduct
+from delivery_location.models import DeliveryLocation
+from product.models import Product
+from supplier.models import Supplier
+from django.shortcuts import redirect, render
+from django.contrib.auth.decorators import user_passes_test
+from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.auth.models import User
+from django.utils.datastructures import MultiValueDictKeyError
+
+
+def client_check(user):
+    try:
+        return Client.objects.get(client_account=user)
+    except ObjectDoesNotExist:
+        return False
+
+
+@user_passes_test(client_check, login_url='Main Page')
+def change_quantity(request, order_id):
+    try:
+        quantity = int(request.GET['quantity'])
+    except MultiValueDictKeyError:
+        return redirect('/client/')
+    except ValueError:
+        return redirect('/client/')
+    try:
+        ordered_product = OrderedProduct.objects.get(id=int(order_id))
+    except ObjectDoesNotExist:
+        return redirect('/client/')
+    if (quantity > 0):
+        ordered_product.increase_quantity(quantity)
+    elif (quantity < 0):
+        ordered_product.decrease_quantity(abs(quantity))
+    return redirect('/client/')
+
+
+@user_passes_test(client_check, login_url='Main Page')
+def delete_order(request, order_id):
+    try:
+        OrderedProduct.objects.get(id=int(order_id)).delete_ordered_product()
+    except ObjectDoesNotExist:
+        return redirect('Main Page')
+    return redirect('/client/')
+
+
+@user_passes_test(client_check, login_url='Main Page')
+def order(request):
+    return render(request, 'ordered_product/new_order.html', {})
+
+
+@user_passes_test(client_check, login_url='Main Page')
+def get_products_by_product_name(request):
+    prod_name = str(request.GET['product_name'])
+    message = ""
+    supplier_products = []
+    try:
+        product = Product.objects.get(product_name=prod_name)
+        supplier_products = SupplierProduct.objects.filter(qr_code=product)
+    except ObjectDoesNotExist:
+        message = "Invalid product name"
+    if not supplier_products and message != "Invalid product name":
+        message = "No products found"
+    return render(
+        request,
+        'ordered_product/new_order.html',
+        {'supplier_products': supplier_products, 'message': message}
+    )
+
+
+@user_passes_test(client_check, login_url='Main Page')
+def get_products_by_client_area(request):
+    message = ""
+    client = client_check(request.user)
+    supplier_products = []
+    deliveries_in_client_area = DeliveryLocation.objects.filter(location=client.area)
+    if not deliveries_in_client_area:
+        message = "No products found in your area"
+    else:
+        for delivery in deliveries_in_client_area:
+            supplier_products += list(SupplierProduct.objects.filter(user_name=delivery.user_name))
+        if supplier_products == []:
+            message = "No products found"
+    return render(
+        request,
+        'ordered_product/new_order.html',
+        {'supplier_products': supplier_products, 'message': message}
+    )
+
+
+@user_passes_test(client_check, login_url='Main Page')
+def get_products_by_supplier_user_name(request):
+    supplier_user_name = str(request.GET['supplier_user_name'])
+    message = ""
+    supplier_products = []
+    try:
+        user = User.objects.get(username=supplier_user_name)
+        supplier = Supplier.objects.get(supplier_account=user)
+    except ObjectDoesNotExist:
+        message = "Supplier no found"
+
+    if message != "Supplier no found":
+        client = client_check(request.user)
+        deliveries = DeliveryLocation.filter_by_supplier_and_location(supplier, client.area)
+        if not deliveries:
+            message = "No products found in your area"
+        else:
+            supplier_products = SupplierProduct.objects.filter(user_name=supplier)
+            if not supplier_products:
+                message = "No products found"
+    return render(
+        request,
+        'ordered_product/new_order.html',
+        {'supplier_products': supplier_products, 'message': message}
+    )
+
+
+@user_passes_test(client_check, login_url='Main Page')
+def find_delivery(request, supplier_product_id):
+    try:
+        supplier_product = SupplierProduct.objects.get(supplier_product_id=int(supplier_product_id))
+    except ObjectDoesNotExist:
+        return redirect('/client/')
+    client = client_check(request.user)
+    deliveries = DeliveryLocation.filter_by_supplier_and_location(supplier_product.user_name, client.area)
+    message = ""
+    if not deliveries:
+        message = "No delivery found at '"+client.area+"'"
+    return render(
+        request,
+        'ordered_product/new_order.html',
+        {'deliveries': deliveries, 'sup_pro_id': supplier_product_id, 'message': message}
+    )
+
+
+@user_passes_test(client_check, login_url='Main Page')
+def order_summary(request, supplier_product_id, delivery_location_id):
+    try:
+        supplier_product = SupplierProduct.objects.get(supplier_product_id=int(supplier_product_id))
+        delivery_location = DeliveryLocation.objects.get(id=int(delivery_location_id))
+    except ObjectDoesNotExist:
+        return redirect('/client/')
+    return render(
+        request,
+        'ordered_product/new_order.html',
+        {'delivery_location': delivery_location, 'supplier_product': supplier_product}
+    )
+
+
+@user_passes_test(client_check, login_url='Main Page')
+def complete_order(request, supplier_product_id, delivery_location_id):
+    try:
+        quantity = int(request.GET['quantity'])
+    except MultiValueDictKeyError:
+        return redirect('/client/')
+    except ValueError:
+        return redirect('/client/')
+    try:
+        delivery_location = DeliveryLocation.objects.get(id=int(delivery_location_id))
+        supplier_product = SupplierProduct.objects.get(supplier_product_id=int(supplier_product_id))
+    except ObjectDoesNotExist:
+        return redirect('/client/')
+
+    OrderedProduct.order(delivery_location, client_check(request.user), supplier_product, quantity)
+    return redirect('/client/')
+
+
+@user_passes_test(client_check, login_url='Main Page')
+def pay_order(request):
+    return render(request, 'ordered_product/pay_order.html', {})

--- a/static/css/new_order.css
+++ b/static/css/new_order.css
@@ -1,0 +1,54 @@
+body,
+		html {
+			margin: 0;
+			padding: 0;
+			height: 100%;
+			background: #7abecc !important;
+		}
+		.user_card {
+			width: 400px;
+			margin-top: auto;
+			margin-bottom: auto;
+			background: #74cfbf;
+			position: relative;
+			left: 330px;
+			display: flex;
+			justify-content: center;
+			flex-direction: column;
+			padding: 10px;
+			box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+			-webkit-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+			-moz-box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+			border-radius: 5px;
+			flex-wrap: nowrap;
+			justify-content: space-between;
+		}
+
+		.form_container {
+			margin-top: 20px;
+		}
+
+		#form-title{
+			color: #fff;
+			
+		}
+
+		.input-group-text {
+			background: #f7ba5b !important;
+			color: white !important;
+			border: 0 !important;
+			border-radius: 0.25rem 0 0 0.25rem !important;
+		}
+		
+		.input_user,
+		.input_pass:focus {
+			box-shadow: none !important;
+			outline: 0px !important;
+		}
+
+		#messages{
+			background-color: grey;
+			color: #fff;
+			padding: 10px;
+			margin-top: 10px;
+		}

--- a/templates/ordered_product/new_order.html
+++ b/templates/ordered_product/new_order.html
@@ -1,0 +1,85 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>new order</title>
+	<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" integrity="sha384-gfdkjb5BdAXd+lj+gudLWI+BXq4IuLW5IT+brZEZsLFm++aCMlF1V92rMkPaX4PP" crossorigin="anonymous">
+	<link rel="stylesheet" href="/static/css/new_order.css">
+</head>
+
+<body>
+    {% include 'buy_together_app/help_parts/nav.html' %}
+	<div class="container mt-5 p-3 align-center">
+		<div class="user_card">
+			{% if supplier_products %}
+				<div class="d-flex justify-content-center">
+					<h3 id="form-title">Results</h3>
+				</div>
+				<b>----------------------------------------------------------</b>
+				{% for sup_product in supplier_products %}
+					<b>product</b> {{sup_product.qr_code.product_name}}<br>
+					<b>product description</b> {{sup_product.qr_code.description}}<br>
+					<b>price</b> {{sup_product.price}}<br>
+					<b>max quantity</b> {{sup_product.quantity}}<br>
+					<b>supplier</b> {{sup_product.user_name.business_name}}<br><br>
+					<div style="text-align:center;">
+						<form action = "/ordered_product/new_order/find_delivery/{{sup_product.supplier_product_id}}" method = "get">
+							<input id="supplier_product" type="submit" value="Select this product" required name="supplier_product"><br>
+						</form>
+					</div>
+					<b>----------------------------------------------------------</b>
+				{% endfor %}
+			{% elif deliveries %}
+					<div class="d-flex justify-content-center">
+						<h3 id="form-title">Deliveries</h3>
+					</div>
+					<b>----------------------------------------------------------</b>
+					{% for delivery in deliveries %}
+							<b>supplier</b> {{delivery.user_name.business_name}}<br>
+							<b>location</b> {{delivery.location}}<br>
+							<b>date</b> {{delivery.date}}<br><br>	
+							<div style="text-align:center;">
+								<form action = "/ordered_product/new_order/order_summary/{{sup_pro_id}},{{delivery.id}}" method = "get">
+									<input id="supplier_product" type="submit" value="Select this delivery" required name="supplier_product"><br>
+								</form>
+							</div>
+							<b>----------------------------------------------------------</b>
+					{% endfor %}
+					<input type="button" value="Go back to products list" onclick="history.back()">
+			{% elif delivery_location %}
+				<div class="d-flex justify-content-center" >
+					<h3 id="form-title">Order summary</h3>
+				</div>
+				<b>----------------------------------------------------------</b>
+				<h5 id="form-title">Product</h5>
+				<b>product</b> {{supplier_product.qr_code.product_name}}<br>
+				<b>product description</b> {{supplier_product.qr_code.description}}<br>
+				<b>price</b> {{supplier_product.price}}<br>
+				<b>max quantity</b> {{supplier_product.quantity}}<br><br>
+				<h5 id="form-title">Delivery</h5>
+				<b>supplier</b> {{delivery_location.user_name.business_name}}<br>
+				<b>location</b> {{delivery_location.location}}<br>
+				<b>date</b> {{delivery_location.date}}<br><br>	
+				
+				<form action = "/ordered_product/new_order/complete_order/{{supplier_product.supplier_product_id}},{{delivery_location.id}}" method = "get">
+					<label for="quantity">Enter quantity:</label>
+					<input id="quantity" type="number" required name="quantity" min="1" max={{supplier_product.quantity}}><br><br>
+					<div style="text-align:center;">
+						<input type="submit" value="add order"><br><br>
+					</div>
+				</form>
+			{% else %}
+				{% if message %}
+					<br><div class="d-flex justify-content-center">
+						<h5 id="form-title">{{ message }}</h5>
+					</div>
+					<br><input type="button" value="Go back" onclick="history.back()">
+				{% endif %}
+			{% endif %}
+		</div>
+	</div>
+</body>
+</html>

--- a/templates/ordered_product/pay_order.html
+++ b/templates/ordered_product/pay_order.html
@@ -1,0 +1,21 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>new order</title>
+	<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" integrity="sha384-gfdkjb5BdAXd+lj+gudLWI+BXq4IuLW5IT+brZEZsLFm++aCMlF1V92rMkPaX4PP" crossorigin="anonymous">
+	<link rel="stylesheet" href="/static/css/new_order.css">
+</head>
+
+<body>
+    {% include 'buy_together_app/help_parts/nav.html' %}
+	<div class="container mt-5 p-3 align-center">
+		<div class="user_card">
+			<br><input type="button" value="Click here to move to the billing page" onclick="history.back()">
+		</div>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
This PR includes:
* html pages - orders list and add a new order.
* views function
* urls file
* tests (one test for each page).
In addition added a new model function that returns the total price of an order (included test for this function).


screen shots:
Search by product name - Apple
![image](https://user-images.githubusercontent.com/101214168/212857430-edade7fb-ac62-4cf0-ad94-a80a0f7b35f1.png)
![image](https://user-images.githubusercontent.com/101214168/212857464-25f1271c-20c0-48cc-a45e-34e3ee6d0cd7.png)
![image](https://user-images.githubusercontent.com/101214168/212857536-edee62b7-2eba-4c4d-b2ec-aa36e47bdbff.png)
View all products in your location - Yuvalim
![image](https://user-images.githubusercontent.com/101214168/212858084-05fbb604-9d05-4408-97f7-d0b63767e866.png)
Search supplier catalog by user name - bestSup1
![image](https://user-images.githubusercontent.com/101214168/212858182-9776cc51-d2c8-4789-a217-1cbb1c076e08.png)






Fixed #78 

Let me know about more needed tests function and etc..
