### PR TITLE
Add supplier feature - display products

### DIFF
--- a/static/css/suppliers.css
+++ b/static/css/suppliers.css
@@ -8,11 +8,38 @@ body{
     align-items: center;
 }
 
-.container_A{
+.container-A{
     background-color: rgb(229, 127, 2);
     height: 500px;
-    width: 30%
+    width:20%
 }
 
-.container_B{background-color: brown;
+.container-B{background-color: brown;
+    width:40%
+}
+
+.container-C{
+    background-color: rgb(34, 214, 234);
+    height: 500px;
+    overflow-y: scroll;
+    position: relative;
+}
+
+.container-text-table{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.text{
+    font-family:"Lucida Console", "Courier New", monospace;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+}
+
+.get_all_button{
+    position: relative;
+    bottom: 0px;
+    left: 30%;
 }

--- a/supplier/tests/test_supplier_page.py
+++ b/supplier/tests/test_supplier_page.py
@@ -1,8 +1,32 @@
 import pytest
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 from django.contrib.auth.models import User
 from supplier.models import Supplier
-from supplier.views import get_supplier
+from supplier.views import action_display_all_products, get_supplier
+from supplier.views import get_product_by_name_and_supplier, action_search_product
+from django.test import RequestFactory
+from supplier import views
+from supplier_product.models import SupplierProduct
+from product.models import Product
+
+
+@pytest.fixture
+def searched_product_string():
+    return 'searched_product'
+
+
+@pytest.fixture
+def get_request():
+    request = RequestFactory().get('/suppliers/')
+    return request
+
+
+@pytest.fixture
+def get_request_with_data(saved_supplier_product0,
+                          searched_product_string):
+    data = {searched_product_string: saved_supplier_product0.qr_code.product_name}
+    request = RequestFactory().get('/suppliers/', data)
+    return request
 
 
 @pytest.fixture
@@ -10,6 +34,36 @@ def non_supplier_mock():
     mock = Mock()
     mock.supplier_account = User.objects.create_user(username='Asaf102',
                                                      password='litza')
+    return mock
+
+
+@pytest.fixture
+def request_searched_product_mock():
+    mock = Mock()
+    mock.GET = {}
+    return mock
+
+
+@pytest.fixture
+def render_mock(monkeypatch):
+    mock = Mock()
+    monkeypatch.setattr(views, views.render.__name__, mock)
+    return mock
+
+
+@pytest.fixture
+def messages_mock(monkeypatch):
+    mock = Mock()
+    monkeypatch.setattr(views, "messages", mock)
+    return mock
+
+
+@pytest.fixture
+def all_products_mock(saved_supplier0,
+                      saved_supplier_product0,
+                      saved_supplier_product1):
+    mock = Mock()
+    mock.return_value = SupplierProduct.objects.filter(user_name=saved_supplier0)
     return mock
 
 
@@ -39,3 +93,77 @@ def test_supplier_check_false(non_supplier_mock):
 def test_supplier_check_true(saved_supplier0):
     assert saved_supplier0 in Supplier.objects.all()
     assert get_supplier(saved_supplier0) == saved_supplier0
+
+
+@pytest.mark.django_db()
+def test_get_product_return_supplier_product(request_searched_product_mock,
+                                             saved_supplier0,
+                                             saved_supplier_product0,
+                                             saved_supplier_product1,
+                                             searched_product_string):
+    assert saved_supplier_product0.user_name == saved_supplier0
+    assert saved_supplier_product1.user_name == saved_supplier0
+    request_searched_product_mock.GET[searched_product_string] = saved_supplier_product0.qr_code.product_name
+    result = get_product_by_name_and_supplier(request_searched_product_mock, saved_supplier0)
+    assert result.first() == saved_supplier_product0
+
+
+@pytest.mark.django_db()
+def test_get_product_sup_dont_have_product(request_searched_product_mock,
+                                           saved_supplier0,
+                                           saved_product0,
+                                           searched_product_string):
+    assert saved_product0 in Product.objects.all()
+    request_searched_product_mock.GET[searched_product_string] = saved_product0.product_name
+    assert get_product_by_name_and_supplier(request_searched_product_mock, saved_supplier0) is None
+
+
+@pytest.mark.django_db()
+def test_get_product_return_none(request_searched_product_mock,
+                                 saved_supplier0,
+                                 searched_product_string):
+
+    request_searched_product_mock.GET[searched_product_string] = 'Fizzibublach'
+    assert get_product_by_name_and_supplier(request_searched_product_mock, saved_supplier0) is None
+
+
+@pytest.mark.django_db()
+def test_searched_product_with_data(get_request_with_data,
+                                    render_mock,
+                                    saved_supplier_product0):
+    response = action_search_product(get_request_with_data, saved_supplier_product0)
+    assert response == render_mock.return_value
+
+    data = {'supplier_products': saved_supplier_product0}
+    assert render_mock.call_args_list == [
+        call(get_request_with_data, 'supplier/suppliers.html', data)
+    ]
+
+
+@pytest.mark.django_db()
+def test_searched_product_without_data(get_request_with_data,
+                                       render_mock,
+                                       messages_mock):
+    response = action_search_product(get_request_with_data, None)
+    assert response == render_mock.return_value
+    messages_mock.info.assert_called_with(
+        get_request_with_data, 'Product Not Found'
+    )
+    assert render_mock.call_args_list == [
+        call(get_request_with_data, 'supplier/suppliers.html')
+    ]
+
+
+@pytest.mark.django_db()
+def test_action_display_all_products(get_request,
+                                     saved_supplier0,
+                                     render_mock,
+                                     saved_supplier_product0,
+                                     saved_supplier_product1):
+    response = action_display_all_products(get_request, saved_supplier0)
+    assert response == render_mock.return_value
+
+    data = set(SupplierProduct.objects.filter(user_name=saved_supplier0))
+    assert render_mock.call_args_list == [
+        call(get_request, 'supplier/suppliers.html', {'supplier_products': data})
+    ]

--- a/supplier/views.py
+++ b/supplier/views.py
@@ -1,6 +1,9 @@
 from django.shortcuts import render
 from supplier.models import Supplier
 from django.contrib.auth.decorators import user_passes_test
+from supplier_product.models import SupplierProduct
+from product.models import Product
+from django.contrib import messages
 
 
 def get_supplier(user):
@@ -10,6 +13,34 @@ def get_supplier(user):
         return False
 
 
+def get_product_by_name_and_supplier(request, supplier):
+    prod_name = request.GET['searched_product']
+    if prod_name:
+        product = Product.filter_name(prod_name).first()
+        supplier_product = SupplierProduct.objects.filter(qr_code=product,
+                                                          user_name=supplier)
+        if supplier_product.exists():
+            return supplier_product
+    return None
+
+
+def action_search_product(request, supplier_product):
+    if supplier_product:
+        return render(request, 'supplier/suppliers.html', {'supplier_products': supplier_product})
+    else:
+        messages.info(request, 'Product Not Found')
+        return render(request, 'supplier/suppliers.html')
+
+
+def action_display_all_products(request, supplier):
+    data = set(SupplierProduct.objects.filter(user_name=supplier))
+    return render(request, 'supplier/suppliers.html', {'supplier_products': data})
+
+
 @user_passes_test(get_supplier, login_url='Not allowed')
 def suppliers_page(request):
-    return render(request, 'supplier/suppliers.html')
+    supplier = get_supplier(request.user)
+    if 'searched_product' in request.GET:
+        return action_search_product(request, get_product_by_name_and_supplier(request, supplier))
+
+    return action_display_all_products(request, supplier)

--- a/templates/buy_together_app/not_allowed.html
+++ b/templates/buy_together_app/not_allowed.html
@@ -1,1 +1,18 @@
-<p>Not Allowed!</p>
+{% include './help_parts/nav.html' %}
+
+<!DOCTYPE html>
+<html>
+    
+<head>
+	<title>Login</title>
+	<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.1/css/all.css" integrity="sha384-gfdkjb5BdAXd+lj+gudLWI+BXq4IuLW5IT+brZEZsLFm++aCMlF1V92rMkPaX4PP" crossorigin="anonymous">
+	<link rel="stylesheet" href="/static/css/login_css.css">
+</head>
+
+<body>
+    <p>Not Allowed!</p>
+</body>
+
+</html>

--- a/templates/supplier/suppliers.html
+++ b/templates/supplier/suppliers.html
@@ -13,14 +13,47 @@
 <body>
     {% include 'buy_together_app/help_parts/nav.html' %}
 
-	<div class="container mt-5 p-3 align-center">
-		<div class="container_A d-flex justify-content-center">
-			<p> here will be something</p>
+	<div class="container">
+		<div class="container-A d-flex justify-content-center">
+			<dov> here will be something</p>
 		</div>
-		<div class="container_A d-flex justify-content-center">
-			<p> here will be something</p>
+		<div class="container-B">
+			
+		</div>
+		<div class="container-text-table">
+			<p class="text">Your items:</p>
+			<div class="container-C justify-content-center rounded">
+				<table class="table table-bordered table-striped mb-0">
+					<thead>
+						<tr>
+							<th scope="col">Product name</th>
+							<th scope="col">Quantity</th>
+							<th scope="col">Price</th>
+						</tr>
+					</thead>
+					<tbody>
+						{% for sup_product in supplier_products %}
+						<tr>
+							<td>{{sup_product.qr_code.product_name}}</td>
+							<td>{{sup_product.quantity}}</td>
+							<td>{{sup_product.price}}</td>
+						</tr>
+						{% endfor %}
+					</tbody>
+				</table>
+				<form><button type="submit" name="all_products" class="btn btn-outline-success get_all_button">All Products</button></form>
+				{% for message in messages %}
+               	<p class="text"> {{message}} </p>
+           		{% endfor %}
+			</div>
+			<form class="input-group form-outline">
+				<input type="search" class="form-control" name="searched_product" placeholder="Search Product" class="form-control" />
+				<button type="submit" class="btn btn-primary">
+				  <i class="fas fa-search"></i>
+				</button>
+			</form>
+		</div>
 
-		</div>
 	</div>
 </body>
 


### PR DESCRIPTION
Adding supplier feature which displays
his products, also include searching product.
based on PR #80.
*missing tests for function action_searched_product

fix #92 

When we enter the supplier page.
![image](https://user-images.githubusercontent.com/83594870/212466508-31db1b53-0be0-4d34-bd13-cdf558001dcb.png)

When we search a product -> Apple
![image](https://user-images.githubusercontent.com/83594870/212466522-72a8ba42-8a87-4a5a-8dc8-7ae1dc5c61cd.png)

When we search a non exists product -> apple 
![image](https://user-images.githubusercontent.com/83594870/212466537-8f784555-09d3-4339-9760-ffca8edabbbd.png)

When we click the "all products" button
![image](https://user-images.githubusercontent.com/83594870/212466601-5360947c-1fd6-4288-b461-5828a1fb18ff.png)

When there are plenty of products
![image](https://user-images.githubusercontent.com/83594870/212479377-8551c4dd-3f5c-45c6-863b-f17181bacd77.png)

![image](https://user-images.githubusercontent.com/83594870/212479385-38cfd5f8-030b-4f43-85a6-bc79846b9b68.png)
